### PR TITLE
Implementing endpoints for member roles

### DIFF
--- a/app/commons/services/permission_service.ts
+++ b/app/commons/services/permission_service.ts
@@ -31,6 +31,8 @@ export class PermissionService {
     const t = member.roles.map((role) => role.permissions)
     let permissions: Permissions[] = []
 
+    permissions = permissions.concat(await this.fromBitfield(member.permissions))
+
     for (const x of t) {
       let a = await this.fromBitfield(x)
       permissions = permissions.concat(a)

--- a/app/domains/members/controllers/member_roles_controller.ts
+++ b/app/domains/members/controllers/member_roles_controller.ts
@@ -1,0 +1,24 @@
+import { inject } from '@adonisjs/core'
+import { HttpContext } from '@adonisjs/core/http'
+import MemberService from '#domains/members/services/member_service'
+import MemberPolicy from '../policies/member_policy.js'
+
+@inject()
+export default class MemberRolesController {
+  constructor(protected memberService: MemberService) {}
+
+  async create({ params, bouncer }: HttpContext) {
+    const { structureId, userId, roleId } = params
+    await bouncer.with(MemberPolicy).authorize('create', structureId)
+
+    await this.memberService.addRole({ structureId, userId, roleId })
+  }
+
+  async delete({ params, bouncer }: HttpContext) {
+    const { structureId, userId, roleId } = params
+
+    await bouncer.with(MemberPolicy).authorize('removeRole', structureId, userId)
+
+    await this.memberService.removeRole({ structureId, userId, roleId })
+  }
+}

--- a/app/domains/members/policies/member_policy.ts
+++ b/app/domains/members/policies/member_policy.ts
@@ -73,4 +73,16 @@ export default class MemberPolicy extends BasePolicy {
       Permissions.MANAGE_MEMBERS,
     ])
   }
+
+  async removeRole(user: User, structureId: string, userId: string) {
+    const structure = await this.structureService.findById(structureId)
+
+    if (structure.ownerId === userId && user.id !== userId) {
+      return false
+    }
+
+    return this.permissionService.hasSomePermissions(user.id, structureId, [
+      Permissions.MANAGE_MEMBERS,
+    ])
+  }
 }

--- a/app/domains/members/routes.ts
+++ b/app/domains/members/routes.ts
@@ -2,6 +2,7 @@ import { middleware } from '#start/kernel'
 import router from '@adonisjs/core/services/router'
 
 const MembersController = () => import('#domains/members/controllers/members_controller')
+const MemberRolesController = () => import('#domains/members/controllers/member_roles_controller')
 
 router
   .group(() => {
@@ -9,6 +10,13 @@ router
       .group(() => {
         router.get('/', [MembersController, 'index'])
         router.post('/', [MembersController, 'store'])
+
+        router
+          .group(() => {
+            router.put('/', [MemberRolesController, 'create'])
+            router.delete('/', [MemberRolesController, 'delete'])
+          })
+          .prefix('/:userId/roles/:roleId')
         router.get('/:memberId', [MembersController, 'show'])
         router.put('/:memberId', [MembersController, 'update'])
         router.delete('/:memberId', [MembersController, 'delete'])

--- a/app/domains/members/services/member_service.ts
+++ b/app/domains/members/services/member_service.ts
@@ -3,6 +3,7 @@ import Member from '#models/member'
 import {
   CreateMemberSchema,
   GetMembersSchema,
+  MemberRoleSchema,
   UpdateMemberSchema,
 } from '#domains/members/validators/member_validator'
 import { inject } from '@adonisjs/core'
@@ -32,7 +33,7 @@ export default class MemberService {
   }
 
   async findById(memberId: string) {
-    return Member.query().where('id', memberId).firstOrFail()
+    return Member.query().where('id', memberId).preload('roles').preload('structure').firstOrFail()
   }
 
   async create({ structureId, userId, permissions }: CreateMemberSchema) {
@@ -56,5 +57,17 @@ export default class MemberService {
   async deleteById(memberId: string) {
     const member = await this.findById(memberId)
     await member.delete()
+  }
+
+  async addRole({ structureId, userId, roleId }: MemberRoleSchema) {
+    const member = await this.findFromStructure(structureId, userId)
+
+    await member.related('roles').attach([roleId])
+  }
+
+  async removeRole({ structureId, userId, roleId }: MemberRoleSchema) {
+    const member = await this.findFromStructure(structureId, userId)
+
+    await member.related('roles').detach([roleId])
   }
 }

--- a/app/domains/members/validators/member_validator.ts
+++ b/app/domains/members/validators/member_validator.ts
@@ -32,3 +32,9 @@ export type CreateMemberSchema = Infer<typeof createMemberValidator> & {
 export type UpdateMemberSchema = Infer<typeof updateMemberValidator> & {
   memberId: string
 }
+
+export type MemberRoleSchema = {
+  structureId: string
+  userId: string
+  roleId: string
+}

--- a/database/factories/member_factory.ts
+++ b/database/factories/member_factory.ts
@@ -2,14 +2,15 @@ import User from '#models/user'
 import Structure from '#models/structure'
 import factory from '@adonisjs/lucid/factories'
 import Member from '#models/member'
+import { Permissions } from '#app/commons/services/permission_service'
 
-export function MemberFactory(user: User, structure: Structure) {
+export function MemberFactory(user: User, structure: Structure, permissions?: Permissions[]) {
   return factory
     .define(Member, async ({}) => {
       return Member.create({
         userId: user.id,
         structureId: structure.id,
-        permissions: 0,
+        permissions: permissions ? permissions.reduce((acc, permission) => permission | acc, 0) : 0,
       })
     })
     .build()

--- a/database/factories/user_factory.ts
+++ b/database/factories/user_factory.ts
@@ -9,7 +9,7 @@ export function UserFactory(status?: UserStatus) {
         lastname: faker.person.lastName(),
         email: faker.internet.email(),
         password: faker.internet.password(),
-        status: status ?? UserStatus.disabled,
+        status: status ?? UserStatus.verified,
         permissions: 0,
       })
     })

--- a/tests/functional/members/role/add.spec.ts
+++ b/tests/functional/members/role/add.spec.ts
@@ -1,0 +1,82 @@
+import Member from '#app/commons/models/member'
+import { Permissions } from '#app/commons/services/permission_service'
+import { MemberFactory } from '#database/factories/member_factory'
+import { RoleFactory } from '#database/factories/role_factory'
+import { StructureFactory } from '#database/factories/structure_factory'
+import { UserFactory } from '#database/factories/user_factory'
+import { test } from '@japa/runner'
+
+test.group('Members add role', () => {
+  test('must return 200 if the structure owner adds a role to a member', async ({
+    assert,
+    client,
+  }) => {
+    const user = await UserFactory().make()
+    const structure = await StructureFactory(user).make()
+
+    const targetUser = await UserFactory().make()
+    const member = await MemberFactory(targetUser, structure).make()
+
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS]).make()
+    const response = await client
+      .put(`/v1/structures/${structure.id}/members/${targetUser.id}/roles/${role.id}`)
+      .loginAs(user)
+
+    response.assertStatus(200)
+
+    const responseMember = await client
+      .get(`/v1/structures/${structure.id}/members/${member.id}`)
+      .loginAs(user)
+
+    assert.equal(responseMember.body().roles.length, 1)
+    assert.equal(responseMember.body().roles[0].id, role.id)
+  }).tags(['members', 'roles'])
+
+  test('must return 200 if an administrator adds a role to a member', async ({
+    client,
+    assert,
+  }) => {
+    const structure = await StructureFactory().make()
+    const user = await UserFactory().make()
+    await MemberFactory(user, structure, [Permissions.ADMINISTRATOR]).make()
+
+    const member = await MemberFactory(await UserFactory().make(), structure).make()
+
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS]).make()
+
+    const response = await client
+      .put(`/v1/structures/${structure.id}/members/${member.userId}/roles/${role.id}`)
+      .loginAs(user)
+    response.assertStatus(200)
+
+    const responseMember = await client
+      .get(`/v1/structures/${structure.id}/members/${member.id}`)
+      .loginAs(user)
+
+    assert.equal(responseMember.body().roles.length, 1)
+    assert.equal(responseMember.body().roles[0].id, role.id)
+  }).tags(['members', 'roles', 'tete'])
+
+  test('must return 403 if a user does not have permissions to add a role to a member', async ({
+    client,
+  }) => {
+    const structure = await StructureFactory().make()
+
+    const user = await UserFactory().make()
+    await MemberFactory(user, structure).make()
+
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS]).make()
+
+    const response = await client
+      .put(`/v1/structures/${structure.id}/members/${user.id}/roles/${role.id}`)
+      .loginAs(user)
+
+    response.assertStatus(403)
+  }).tags(['members', 'roles'])
+
+  test('must return 401 if the user is not authenticated', async ({ client }) => {
+    const response = await client.put(`/v1/structures/1/members/1/roles/1`)
+
+    response.assertStatus(401)
+  }).tags(['members', 'roles'])
+})

--- a/tests/functional/members/role/remove.spec.ts
+++ b/tests/functional/members/role/remove.spec.ts
@@ -1,0 +1,74 @@
+import { Permissions } from '#app/commons/services/permission_service'
+import { MemberFactory } from '#database/factories/member_factory'
+import { RoleFactory } from '#database/factories/role_factory'
+import { StructureFactory } from '#database/factories/structure_factory'
+import { UserFactory } from '#database/factories/user_factory'
+import { test } from '@japa/runner'
+
+test.group('Members role remove', () => {
+  test('must return 200 if the structure owner removes a role from a member', async ({
+    assert,
+    client,
+  }) => {
+    const user = await UserFactory().make()
+    const structure = await StructureFactory(user).make()
+
+    const targetUser = await UserFactory().make()
+    const member = await MemberFactory(targetUser, structure).make()
+
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS], member).make()
+
+    const response = await client
+      .delete(`/v1/structures/${structure.id}/members/${targetUser.id}/roles/${role.id}`)
+      .loginAs(user)
+
+    response.assertStatus(200)
+
+    const responseMember = await client
+      .get(`/v1/structures/${structure.id}/members/${member.id}`)
+      .loginAs(user)
+
+    responseMember.assertStatus(200)
+    assert.equal(responseMember.body().roles.length, 0)
+  }).tags(['members', 'roles'])
+
+  test('must return 200 if an administrator removes a role from a member', async ({ client }) => {
+    const structure = await StructureFactory().make()
+
+    const user = await UserFactory().make()
+    await MemberFactory(user, structure, [Permissions.MANAGE_MEMBERS]).make()
+
+    const targetUser = await UserFactory().make()
+    const member = await MemberFactory(targetUser, structure).make()
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS], member).make()
+
+    const response = await client
+      .delete(`/v1/structures/${structure.id}/members/${targetUser.id}/roles/${role.id}`)
+      .loginAs(user)
+
+    response.assertStatus(200)
+  }).tags(['members', 'roles'])
+
+  test('must return 403 if a user does not have permissions to remove a role from a member', async ({
+    client,
+  }) => {
+    const structure = await StructureFactory().make()
+    const user = await UserFactory().make()
+    await MemberFactory(user, structure).make()
+
+    const member = await MemberFactory(await UserFactory().make(), structure).make()
+    const role = await RoleFactory(structure, [Permissions.VIEW_LOGS], member).make()
+
+    const response = await client
+      .delete(`/v1/structures/${structure.id}/members/${member.userId}/roles/${role.id}`)
+      .loginAs(user)
+
+    response.assertStatus(403)
+  }).tags(['members', 'roles'])
+
+  test('must return 401 if the user is not authenticated', async ({ client }) => {
+    const response = await client.delete(`/v1/structures/1/members/1/roles/1`).send()
+
+    response.assertStatus(401)
+  }).tags(['members', 'roles'])
+})


### PR DESCRIPTION
Added two endpoints for adding or removing a role from a member, along with several tests and a patch to the `getUserPermissionsForStructure` method in `PermissionService` to add the permissions assigned to the `permissions` field in the `Member` model.